### PR TITLE
chore: fix code-style, include tests when linting

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,3 +2,4 @@
 . "$(dirname "$0")/_/husky.sh"
 
 yarn test
+yarn lint

--- a/package.json
+++ b/package.json
@@ -70,8 +70,8 @@
   "scripts": {
     "build": "rimraf ./dist && tsc -p ./tsconfig.json --emitDeclarationOnly && node build.js",
     "tsc:check": "tsc --project ./tsconfig.json --noEmit",
-    "lint": "eslint \"src/**/*.ts\"",
-    "lint:fix": "eslint --fix \"src/**/*.ts\"",
+    "lint": "eslint \"src/**/*.ts\" \"test/**/*.ts\"",
+    "lint:fix": "eslint --fix \"src/**/*.ts\" \"test/**/*.ts\"",
     "test": "jest -c jest.config.js",
     "test:watch": "jest -c jest.config.js --watchAll",
     "prepack": "yarn build",

--- a/src/cron-parser.ts
+++ b/src/cron-parser.ts
@@ -113,10 +113,10 @@ function parseElement(element: string, constraint: IConstraint): Set<number> {
   }
 
   // Detect if the element is a range.
-  // eslint-disable-next-line security/detect-unsafe-regex
-  const rangeSegments = /^((([0-9a-zA-Z]+)-([0-9a-zA-Z]+))|\*)(\/([0-9]+))?$/.exec(
-    element
-  )
+  /* eslint-disable security/detect-unsafe-regex */
+  const rangeSegments =
+    /^((([0-9a-zA-Z]+)-([0-9a-zA-Z]+))|\*)(\/([0-9]+))?$/.exec(element)
+  /* eslint-enable security/detect-unsafe-regex */
 
   // If not, it must be a single element.
   if (rangeSegments === null) {

--- a/src/cron.ts
+++ b/src/cron.ts
@@ -434,9 +434,10 @@ export class Cron {
       const year =
         maxYear -
         Math.floor((startIndexMonth + i) / this.reversed.months.length)
-      const month = this.reversed.months[
-        (startIndexMonth + i) % this.reversed.months.length
-      ]
+      const month =
+        this.reversed.months[
+          (startIndexMonth + i) % this.reversed.months.length
+        ]
       const isStartMonth =
         year === startDateElements.year && month === startDateElements.month
 
@@ -526,9 +527,8 @@ export class Cron {
 
   /** Returns true when there is a cron date at the given date. */
   public matchDate(date: Date): boolean {
-    const { second, minute, hour, day, month, weekday } = extractDateElements(
-      date
-    )
+    const { second, minute, hour, day, month, weekday } =
+      extractDateElements(date)
 
     return (
       this.seconds.indexOf(second) !== -1 &&

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -39,9 +39,7 @@ export function longTimeout(
 }
 
 /* Extracts second, minute, hour, date, month and the weekday from a date. */
-export function extractDateElements(
-  date: Date
-): {
+export function extractDateElements(date: Date): {
   second: number
   minute: number
   hour: number

--- a/test/cron-parser.test.ts
+++ b/test/cron-parser.test.ts
@@ -29,14 +29,8 @@ describe('parseCronExpression', () => {
   })
 
   test('Should correctly parse lists', () => {
-    const {
-      seconds,
-      minutes,
-      hours,
-      days,
-      months,
-      weekdays,
-    } = parseCronExpression('1,2 2,3,4 4,5,6 7,8 9,10,11 0,1,2')
+    const { seconds, minutes, hours, days, months, weekdays } =
+      parseCronExpression('1,2 2,3,4 4,5,6 7,8 9,10,11 0,1,2')
 
     expect(seconds).toStrictEqual([1, 2])
     expect(minutes).toStrictEqual([2, 3, 4])
@@ -47,38 +41,13 @@ describe('parseCronExpression', () => {
   })
 
   test('Should correctly parse ranges', () => {
-    const {
-      seconds,
-      minutes,
-      hours,
-      days,
-      months,
-      weekdays,
-    } = parseCronExpression('1-3 2-6 3-22 4-10 5-11 0-6')
+    const { seconds, minutes, hours, days, months, weekdays } =
+      parseCronExpression('1-3 2-6 3-22 4-10 5-11 0-6')
 
     expect(seconds).toStrictEqual([1, 2, 3])
     expect(minutes).toStrictEqual([2, 3, 4, 5, 6])
     expect(hours).toStrictEqual([
-      3,
-      4,
-      5,
-      6,
-      7,
-      8,
-      9,
-      10,
-      11,
-      12,
-      13,
-      14,
-      15,
-      16,
-      17,
-      18,
-      19,
-      20,
-      21,
-      22,
+      3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22,
     ])
     expect(days).toStrictEqual([4, 5, 6, 7, 8, 9, 10])
     expect(months).toStrictEqual([4, 5, 6, 7, 8, 9, 10])
@@ -86,39 +55,13 @@ describe('parseCronExpression', () => {
   })
 
   test('Should correctly parse ranges in lists', () => {
-    const {
-      seconds,
-      minutes,
-      hours,
-      days,
-      months,
-      weekdays,
-    } = parseCronExpression('1-3,7,9-11 2,3,2-6 1,3-22,2 2,3,4-10 1,5-11 0-6,7')
+    const { seconds, minutes, hours, days, months, weekdays } =
+      parseCronExpression('1-3,7,9-11 2,3,2-6 1,3-22,2 2,3,4-10 1,5-11 0-6,7')
 
     expect(seconds).toStrictEqual([1, 2, 3, 7, 9, 10, 11])
     expect(minutes).toStrictEqual([2, 3, 4, 5, 6])
     expect(hours).toStrictEqual([
-      1,
-      2,
-      3,
-      4,
-      5,
-      6,
-      7,
-      8,
-      9,
-      10,
-      11,
-      12,
-      13,
-      14,
-      15,
-      16,
-      17,
-      18,
-      19,
-      20,
-      21,
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
       22,
     ])
     expect(days).toStrictEqual([2, 3, 4, 5, 6, 7, 8, 9, 10])
@@ -127,14 +70,8 @@ describe('parseCronExpression', () => {
   })
 
   test('Should correctly parse step values', () => {
-    const {
-      seconds,
-      minutes,
-      hours,
-      days,
-      months,
-      weekdays,
-    } = parseCronExpression('*/10 2-10/3 0-9/2 5-11/4 */2 0-6/3')
+    const { seconds, minutes, hours, days, months, weekdays } =
+      parseCronExpression('*/10 2-10/3 0-9/2 5-11/4 */2 0-6/3')
 
     expect(seconds).toStrictEqual([0, 10, 20, 30, 40, 50])
     expect(minutes).toStrictEqual([2, 5, 8])


### PR DESCRIPTION
The current `master` does not pass the specified linting rules. Additionals the `test` directory is not linted at all.

This PR adds:
- linting of the `test` directory
- adds `yarn lint` to the husky pre-commit hook so this won't occur again
- fixes provided by `lint:fix`