### PR TITLE
fix: correctly parse weekday ranges that include sunday

### DIFF
--- a/src/cron-parser.ts
+++ b/src/cron-parser.ts
@@ -49,13 +49,13 @@ const weekdayConstraint: IConstraint = {
   min: 0,
   max: 7,
   aliases: {
-    'sun': '0',
     'mon': '1',
     'tue': '2',
     'wed': '3',
     'thu': '4',
     'fri': '5',
     'sat': '6',
+    'sun': '7'
   },
 }
 

--- a/src/cron-parser.ts
+++ b/src/cron-parser.ts
@@ -193,6 +193,8 @@ export function parseCronExpression(cronExpression: string): Cron {
     months: new Set(
       Array.from(parseElement(rawMonths, monthConstraint)).map((x) => x - 1)
     ),
-    weekdays: new Set(Array.from(parseElement(rawWeekdays, weekdayConstraint)).map((x) => x % 7)),
+    weekdays: new Set(
+      Array.from(parseElement(rawWeekdays, weekdayConstraint)).map((x) => x % 7)
+    ),
   })
 }

--- a/src/cron-parser.ts
+++ b/src/cron-parser.ts
@@ -47,9 +47,8 @@ const monthConstraint: IConstraint = {
 
 const weekdayConstraint: IConstraint = {
   min: 0,
-  max: 6,
+  max: 7,
   aliases: {
-    '7': '0',
     'sun': '0',
     'mon': '1',
     'tue': '2',
@@ -194,6 +193,6 @@ export function parseCronExpression(cronExpression: string): Cron {
     months: new Set(
       Array.from(parseElement(rawMonths, monthConstraint)).map((x) => x - 1)
     ),
-    weekdays: parseElement(rawWeekdays, weekdayConstraint),
+    weekdays: new Set(Array.from(parseElement(rawWeekdays, weekdayConstraint)).map((x) => x % 7)),
   })
 }

--- a/test/cron-parser.test.ts
+++ b/test/cron-parser.test.ts
@@ -220,7 +220,16 @@ describe('parseCronExpression', () => {
     })
   })
 
-  test('Should correctly parse weekday names', () => {
+  test('Should correctly parse weekday names with range', () => {
+    expect(parseCronExpression('0 0 0 1 1 sat-sun')).toMatchObject({
+      seconds: [0],
+      minutes: [0],
+      hours: [0],
+      days: [1],
+      months: [0],
+      weekdays: [0,6],
+    })
+
     expect(parseCronExpression('0 0 0 1 1 sun')).toMatchObject({
       seconds: [0],
       minutes: [0],

--- a/test/cron-parser.test.ts
+++ b/test/cron-parser.test.ts
@@ -17,6 +17,17 @@ describe('parseCronExpression', () => {
     })
   })
 
+  test('Should correctly parse weekday range with 7', () => {
+    expect(parseCronExpression('1 2 3 4 5 6-7')).toMatchObject({
+      seconds: [1],
+      minutes: [2],
+      hours: [3],
+      days: [4],
+      months: [4],
+      weekdays: [0, 6],
+    })
+  })
+
   test('Should correctly parse single numbers', () => {
     expect(parseCronExpression('1 2 3 4 5 6')).toMatchObject({
       seconds: [1],
@@ -408,11 +419,11 @@ describe('parseCronExpression', () => {
       )
     )
     expect(() => parseCronExpression('* * * * * 8')).toThrow(
-      new Error('Failed to parse 8: 8 is outside of constraint range of 0 - 6.')
+      new Error('Failed to parse 8: 8 is outside of constraint range of 0 - 7.')
     )
     expect(() => parseCronExpression('* * * * * -1')).toThrow(
       new Error(
-        'Failed to parse -1: -1 is outside of constraint range of 0 - 6.'
+        'Failed to parse -1: -1 is outside of constraint range of 0 - 7.'
       )
     )
     expect(() => parseCronExpression('** * * * * *')).toThrow(

--- a/test/cron.test.ts
+++ b/test/cron.test.ts
@@ -306,7 +306,7 @@ describe('constructor', () => {
           hours: new Set([1]),
           days: new Set([1]),
           months: new Set([1]),
-          weekdays: new Set([7]),
+          weekdays: new Set([8]),
         })
     ).toThrow()
   })


### PR DESCRIPTION
This should solve the issue with parsing ranges like `6-7` for the weekday.

The tests are passing and with that small post processing of the weekdays element ( modulo + set -> remove duplicates and still have 0-6 ) it should do the exact same thing as before.

It should fix #282 