### PR TITLE
fix: Sundays can begin weekday ranges

### DIFF
--- a/src/cron-parser.ts
+++ b/src/cron-parser.ts
@@ -125,7 +125,7 @@ function parseElement(element: string, constraint: IConstraint): Set<number> {
 	}
 
 	// If it is a range, get start and end of the range.
-	const parsedStart =
+	let parsedStart =
 		rangeSegments[1] === '*'
 			? constraint.min
 			: parseSingleElement(rangeSegments[3])
@@ -134,6 +134,16 @@ function parseElement(element: string, constraint: IConstraint): Set<number> {
 		rangeSegments[1] === '*'
 			? constraint.max
 			: parseSingleElement(rangeSegments[4])
+
+	// need to catch Sunday, which gets parsed here as 7, but is also legitimate at the start of a range as 0, to avoid the out of order error
+	if (
+		constraint === weekdayConstraint
+		&& parsedStart === 7
+		// this check ensures that sun-sun is not incorrectly parsed as [0,1,2,3,4,5,6]
+		&& parsedEnd !== 7
+	) {
+		parsedStart = 0
+	}
 
 	if (parsedStart > parsedEnd) {
 		throw new Error(

--- a/src/cron-parser.ts
+++ b/src/cron-parser.ts
@@ -137,10 +137,10 @@ function parseElement(element: string, constraint: IConstraint): Set<number> {
 
 	// need to catch Sunday, which gets parsed here as 7, but is also legitimate at the start of a range as 0, to avoid the out of order error
 	if (
-		constraint === weekdayConstraint
-		&& parsedStart === 7
+		constraint === weekdayConstraint &&
+		parsedStart === 7 &&
 		// this check ensures that sun-sun is not incorrectly parsed as [0,1,2,3,4,5,6]
-		&& parsedEnd !== 7
+		parsedEnd !== 7
 	) {
 		parsedStart = 0
 	}

--- a/test/cron-parser.test.ts
+++ b/test/cron-parser.test.ts
@@ -310,6 +310,24 @@ describe('parseCronExpression', () => {
 			months: [0],
 			weekdays: [4, 5, 6],
 		})
+
+		expect(parseCronExpression('0 0 0 1 1 Sun-wed,Fri')).toMatchObject({
+			seconds: [0],
+			minutes: [0],
+			hours: [0],
+			days: [1],
+			months: [0],
+			weekdays: [0, 1, 2, 3, 5],
+		})
+
+		expect(parseCronExpression('0 0 0 1 1 sun-sun')).toMatchObject({
+			seconds: [0],
+			minutes: [0],
+			hours: [0],
+			days: [1],
+			months: [0],
+			weekdays: [0],
+		})
 	})
 
 	test('Should default to 0 when no seconds are specified in the cron expression', () => {


### PR DESCRIPTION
This PR fixes a bug where weekday ranges starting with `sun` would incorrectly throw an out of order error.

For example:

```js
parseCronExpression('00 12 * * Sun-wed,fri')
// Throws -- parse error: Error: Failed to parse Sun-wed: Invalid range (start: 7, end: 3).
```

Tests were also updated to check for:

1. the case outlined above, and
2. to ensure that `sun-sun` was not treated as a full week range, but only as a single day. I couldn't find the spec for this, but instead very scientifically tried it out at [crontab.guru](https://crontab.guru/#5_4_*_*_sun-sun) to see what it would yield.

