### PR TITLE
fix: make @monthly macro work correctly

### DIFF
--- a/src/cron-parser.ts
+++ b/src/cron-parser.ts
@@ -62,7 +62,7 @@ const weekdayConstraint: IConstraint = {
 const timeNicknames: Record<string, string | undefined> = {
 	'@yearly': '0 0 1 1 *',
 	'@annually': '0 0 1 1 *',
-	'@monthly': '0 0 1 1 *',
+	'@monthly': '0 0 1 * *',
 	'@weekly': '0 0 * * 0',
 	'@daily': '0 0 * * *',
 	'@hourly': '0 * * * *',

--- a/test/cron-parser.test.ts
+++ b/test/cron-parser.test.ts
@@ -349,7 +349,7 @@ describe('parseCronExpression', () => {
 
 	test('Should parse @monthly', () => {
 		expect(parseCronExpression('@MONTHLY')).toStrictEqual(
-			parseCronExpression('0 0 1 1 *'),
+			parseCronExpression('0 0 1 * *'),
 		)
 	})
 


### PR DESCRIPTION
@monthly macro was incorrectly mapped in both the parser and the test file, as described in #323. 

Fixed