### PR TITLE
chore: fix wrong compiler options instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ cron.matchDate(date: Date): boolean
 
 You can schedule tasks to be executed based on a cron expression. _cron-schedule_ comes with 2 different schedulers.
 
-If you use TypeScript, make sure you set `comilerOptions.nodeResolution` to `node16` or `nodenext`.
+If you use TypeScript, make sure you set `compilerOptions.moduleResolution` to `node16` or `nodenext`.
 
 ### 1. Timer based scheduler
 


### PR DESCRIPTION
This pull request includes a minor correction to the `README.md` file. The change fixes a typo in the TypeScript configuration instructions.

Documentation update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L114-R114): Corrected the `compilerOptions.moduleResolution` setting from `comilerOptions.nodeResolution` to `compilerOptions.moduleResolution`.Corrected Typescript config instruction:
